### PR TITLE
change shingleSet into doublelayered map

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/algorithms/backtracking.go
+++ b/pkg/algorithms/backtracking.go
@@ -1,1 +1,0 @@
-package algorithms

--- a/pkg/algorithms/dictionary.go
+++ b/pkg/algorithms/dictionary.go
@@ -6,24 +6,23 @@ import "fmt"
 type dictionary map[uint64]string
 
 // This is a local dictionary to store string and hash transition.
-var dict = make(dictionary)
-
+var localDictionary = make(dictionary)
 
 // addToDict converts a string in a hash value and add this pair of string and hash to the local dictionary.
 // It returns the hash value of the string and errors out if there exist hash collision or hash convection error.
 func (d *dictionary) addToDict(entry string) (uint64, error) {
 	if entry == "" {
-		return 0,fmt.Errorf("no empty string should be added to the dictionary")
+		return 0, fmt.Errorf("no empty string should be added to the dictionary")
 	}
 	hash, err := stringTo64Hash(entry)
 	if err != nil {
 		return 0, fmt.Errorf("failed to convert string '%s' to hash value, %v", entry, err)
 	}
 
-	if val, isExist := dict[hash]; isExist && val != entry {
+	if val, isExist := (*d)[hash]; isExist && val != entry {
 		return 0, fmt.Errorf("hash collision for string '%s' and '%s', %v", val, entry, err)
 	} else if !isExist {
-		dict[hash] = entry
+		(*d)[hash] = entry
 	}
 	return hash, nil
 }
@@ -31,7 +30,7 @@ func (d *dictionary) addToDict(entry string) (uint64, error) {
 // lookupDict returns string that maps to the hash value.
 // The function returns error if hash value does not exist in the dictionary or the mapped string is empty.
 func (d *dictionary) lookupDict(hash uint64) (string, error) {
-	val, isExist := dict[hash]
+	val, isExist := (*d)[hash]
 	if !isExist {
 		return "", fmt.Errorf("hash value %d does not exist in the local dictionary", hash)
 	}

--- a/pkg/algorithms/dictionary_test.go
+++ b/pkg/algorithms/dictionary_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAddToDict(t *testing.T) {
+	testDict := make(dictionary)
 	// Test that it can add the same string exist in the dictionary.
 	inputs := []string{
 		"abc",
@@ -15,7 +16,7 @@ func TestAddToDict(t *testing.T) {
 		"abc",
 	}
 	for _, in := range inputs {
-		_, err := dict.addToDict(in)
+		_, err := testDict.addToDict(in)
 		assert.NoError(t, err)
 	}
 
@@ -25,18 +26,19 @@ func TestAddToDict(t *testing.T) {
 	_, err := stringTo64Hash(s)
 	require.NoError(t, err, "failed to convert string to hash")
 
-	hash, err := dict.addToDict(s)
-	dict[hash] = sFail
+	hash, err := testDict.addToDict(s)
+	testDict[hash] = sFail
 	assert.NoError(t, err, "dictionary added a collision")
 }
 
 func TestLookupDict(t *testing.T) {
+	testDict := make(dictionary)
 	t.Run("Dictionary lookup", func(t *testing.T) {
 		s := "abcd"
-		hash, err := dict.addToDict(s)
+		hash, err := testDict.addToDict(s)
 		require.NoError(t, err)
 
-		lookup, err := dict.lookupDict(hash)
+		lookup, err := testDict.lookupDict(hash)
 		assert.NoError(t, err)
 		assert.Equal(t, s, lookup)
 	})
@@ -44,7 +46,7 @@ func TestLookupDict(t *testing.T) {
 	t.Run("Lookup nonexistent item", func(t *testing.T) {
 		hash, err := stringTo64Hash("This does not exist")
 		require.NoError(t, err, "failed to convert string to hash")
-		_, err = dict.lookupDict(hash)
+		_, err = testDict.lookupDict(hash)
 		assert.Error(t, err)
 	})
 

--- a/pkg/algorithms/hashShingling_test.go
+++ b/pkg/algorithms/hashShingling_test.go
@@ -9,46 +9,58 @@ import (
 
 // TestAddToHashShingleSet is a sequential test that adds shingles to the local shingle set.
 func TestAddToHashShingleSet(t *testing.T) {
+	testShingleSet := make(hashShingleSet)
 	// Add different shingles and see they are added to the local shingle set.
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 1, second: 2}: 2})
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 2, second: 2}: 2})
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 1, second: 3}: 3})
-	assert.Equal(t, 3, len(localHashShingleSet))
+	testShingleSet.AddShingle(1, 2, 2)
+	testShingleSet.AddShingle(2, 2, 2)
+	testShingleSet.AddShingle(1, 3, 3)
+	assert.Equal(t, 3, testShingleSet.Size())
 
 	// Add shingles of different counts and check if max is updated.
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 1, second: 2}: 2})
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 1, second: 2}: 3})
-	assert.Equal(t, 3, int(localHashShingleSet[hashShingle{first: 1, second: 2}]))
+	testShingleSet.AddShingle(1, 2, 2)
+	testShingleSet.AddShingle(1, 2, 3)
+	val, err := testShingleSet.getShingleCount(1, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, int(val))
 
 	// Add shingles of same and less counts and see nothing changed.
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 2, second: 4}: 1})
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 2, second: 4}: 9})
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 2, second: 4}: 2})
-	assert.Equal(t, 9, int(localHashShingleSet[hashShingle{first: 2, second: 4}]))
+	testShingleSet.AddShingle(2, 4, 1)
+	testShingleSet.AddShingle(2, 4, 9)
+	testShingleSet.AddShingle(2, 4, 2)
+	val, err = testShingleSet.getShingleCount(2, 4)
+	assert.NoError(t, err)
+	assert.Equal(t, 9, int(val))
 }
 
 // TestRemoveFromHashShingleSet is a sequential test that removes shingles from the local shingle set.
 func TestRemoveFromHashShingleSet(t *testing.T) {
-	localHashShingleSet.addToHashShingleSet(&hashShingleSet{hashShingle{first: 3, second: 2}: 1})
-	err := localHashShingleSet.removeFromHashShingleSet(&hashShingleSet{hashShingle{first: 3, second: 2}: 1})
+	testShingleSet := make(hashShingleSet)
+
+	testShingleSet.AddShingle(3, 2, 1)
+	rmShingleSet := hashShingleSet{3: {2: 1}}
+	err := testShingleSet.removeFromHashShingleSet(&rmShingleSet)
 	assert.NoError(t, err)
+	assert.Zero(t, len(testShingleSet))
 
 	// Test function throwing error if removing shingle does not exist.
-	nonExistingShingle := hashShingleSet{hashShingle{first: 400, second: 400}: 400}
-	_, isExist := localHashShingleSet[hashShingle{first: 400, second: 400}]
+	nonExistingShingle := hashShingleSet{400: {400: 400}}
+	isExist := testShingleSet.Exist(400, 400)
 	require.False(t, isExist)
-	err = localHashShingleSet.removeFromHashShingleSet(&nonExistingShingle)
+	err = testShingleSet.removeFromHashShingleSet(&nonExistingShingle)
 	assert.Error(t, err)
 
 	// Test function throwing error if removing shingle has different count.
-	localHashShingleSet[hashShingle{first: 400, second: 400}] = 300
-	count := localHashShingleSet[hashShingle{first: 400, second: 400}]
-	require.Equal(t, 300, int(count))
-	err = localHashShingleSet.removeFromHashShingleSet(&nonExistingShingle)
+	testShingleSet.AddShingle(400, 400, 400)
+	wrongShingleCount := hashShingleSet{400: {400: 300}}
+	count, err := testShingleSet.getShingleCount(400, 400)
+	require.NoError(t, err)
+	require.Equal(t, 400, int(count))
+	err = testShingleSet.removeFromHashShingleSet(&wrongShingleCount)
 	assert.Error(t, err)
 }
 
 func TestConvertChunksToShingleSet(t *testing.T) {
+	testShingleSet := make(hashShingleSet)
 	input := []struct {
 		arr     []string
 		setSize int
@@ -81,54 +93,59 @@ func TestConvertChunksToShingleSet(t *testing.T) {
 		},
 	}
 	for _, in := range input {
-		shingleSet, err := convertChunksToShingleSet(&in.arr)
+		dict, err := testShingleSet.addChunksToShingleSet(&in.arr)
 		if in.noError {
 			assert.NoError(t, err, "error converting", in)
-			assert.Equal(t, in.setSize, len(*shingleSet))
+			assert.Equal(t, in.setSize, len(*dict))
 		} else {
 			assert.Error(t, err, "no error converting", in)
 		}
 	}
 
+	testShingleSet.Clear()
+
 	// Test shingle counting.
-	shingleSet, err := convertChunksToShingleSet(&[]string{"abc", "abc", "abc"})
+	_, err := testShingleSet.addChunksToShingleSet(&[]string{"abc", "abc", "abc"})
 	require.NoError(t, err, "error converting string chunks into shingle set")
 	hash, err := stringTo64Hash("abc")
 	require.NoError(t, err, "error converting string to hash")
-	count := (*shingleSet)[hashShingle{hash, hash}]
+	count, err := testShingleSet.getShingleCount(hash, hash)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, int(count))
 }
 
 // TestShingleCount tests the getter, setter, and adder for the shingle count.
 func TestShingleCount(t *testing.T) {
-	testShingle := hashShingle{123, 234}
-	testSet := hashShingleSet{testShingle: 1}
+	testShingleSet := make(hashShingleSet)
+	first := uint64(1234)
+	second := uint64(4321)
+	testShingleSet.AddShingle(first, second, 1)
 
-	val, err := testSet.getShingleCount(testShingle)
+	val, err := testShingleSet.getShingleCount(first, second)
 	assert.NoError(t, err)
-	assert.Equal(t, 1, val)
+	assert.Equal(t, 1, int(val))
 
-	val, err = testSet.addShingleCount(testShingle, 1)
+	val, err = testShingleSet.addShingleCount(first, second, 1)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, val)
-	assertShingleCount(t, testSet, testShingle, 2)
+	assert.Equal(t, 2, int(val))
+	assertShingleCount(t, testShingleSet, first, second, 2)
 
-	val, err = testSet.addShingleCount(testShingle, -2)
+	val, err = testShingleSet.addShingleCount(first, second, -2)
 	assert.NoError(t, err)
-	assert.Equal(t, 0, val)
-	assertShingleCount(t, testSet, testShingle, 0)
+	assert.Equal(t, 0, int(val))
+	assertShingleCount(t, testShingleSet, first, second, 0)
 
-	val, err = testSet.addShingleCount(testShingle, -1)
+	_, err = testShingleSet.addShingleCount(first, second, -1)
 	assert.Error(t, err)
-	assertShingleCount(t, testSet, testShingle, 0)
+	assertShingleCount(t, testShingleSet, first, second, 0)
 
-	err = testSet.setShingleCount(testShingle, 1)
+	err = testShingleSet.setShingleCount(first, second, 1)
 	assert.NoError(t, err)
-	assertShingleCount(t, testSet, testShingle, 1)
+	assertShingleCount(t, testShingleSet, first, second, 1)
 }
 
-func assertShingleCount(t *testing.T, set hashShingleSet, shingle hashShingle, expectedCount int) {
-	val, err := set.getShingleCount(shingle)
+func assertShingleCount(t *testing.T, set hashShingleSet, first, second uint64, expectedCount int) {
+	val, err := set.getShingleCount(first, second)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedCount, val)
+	assert.Equal(t, expectedCount, int(val))
 }


### PR DESCRIPTION
This commit enahces lookup speed for potential shingle tail. This is necessary for backtracking to be implemented efficiently. Second part of the shingle is an address to a map of tails with counts as value.