### PR TITLE
[fix] Disallow serverSync from choosing an ip

### DIFF
--- a/pkg/lib/algorithm/full_sync/sync.go
+++ b/pkg/lib/algorithm/full_sync/sync.go
@@ -119,8 +119,8 @@ func (f *fullSync) SyncClient(ip string, port int) error {
 	return nil
 }
 
-func (f *fullSync) SyncServer(ip string, port int) error {
-	server, err := genSync.NewTcpConnection(ip, port)
+func (f *fullSync) SyncServer(port int) error {
+	server, err := genSync.NewTcpConnection("", port)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/algorithm/full_sync/sync_test.go
+++ b/pkg/lib/algorithm/full_sync/sync_test.go
@@ -71,7 +71,7 @@ func TestNewFullSetSync(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			err := client.SyncServer("", 8080)
+			err := client.SyncServer(8080)
 			assert.NoError(t, err)
 			wg.Done()
 		}()

--- a/pkg/lib/algorithm/iblt/sync.go
+++ b/pkg/lib/algorithm/iblt/sync.go
@@ -241,8 +241,8 @@ func (i *ibltSync) SyncClient(ip string, port int) error {
 
 	return nil
 }
-func (i *ibltSync) SyncServer(ip string, port int) error {
-	server, err := genSync.NewTcpConnection(ip, port)
+func (i *ibltSync) SyncServer(port int) error {
+	server, err := genSync.NewTcpConnection("", port)
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/algorithm/iblt/sync_test.go
+++ b/pkg/lib/algorithm/iblt/sync_test.go
@@ -77,7 +77,7 @@ func TestWithDataLen(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			err := client.SyncServer("", 8080)
+			err := client.SyncServer(8080)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -155,7 +155,7 @@ func TestWithHashFunc(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			err := client.SyncServer("", 8080)
+			err := client.SyncServer(8080)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -240,7 +240,7 @@ func TestNewIBLTSetSyncWithDifferentDestinations(t *testing.T) {
 		t.Log("syncing with client 1 in the first address")
 		wg.Add(1)
 		go func() {
-			err := client1.SyncServer("", port1)
+			err := client1.SyncServer(port1)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -255,7 +255,7 @@ func TestNewIBLTSetSyncWithDifferentDestinations(t *testing.T) {
 		t.Log("syncing with client 2 in the second address")
 		wg.Add(1)
 		go func() {
-			err := client2.SyncServer("", port2)
+			err := client2.SyncServer(port2)
 			assert.NoError(t, err)
 			wg.Done()
 		}()
@@ -335,7 +335,7 @@ func TestIbltSync_SuccessRate(t *testing.T) {
 				var wg sync.WaitGroup
 				wg.Add(1)
 				go func() {
-					client.SyncServer("", 8080+index)
+					client.SyncServer(8080 + index)
 					wg.Done()
 				}()
 				server.SyncClient("", 8080+index)

--- a/pkg/lib/genSync/interface.go
+++ b/pkg/lib/genSync/interface.go
@@ -9,7 +9,7 @@ type GenSync interface {
 	DeleteElement(elem interface{}) error
 
 	SyncClient(ip string, port int) error
-	SyncServer(ip string, port int) error
+	SyncServer(port int) error
 
 	GetLocalSet() *set.Set
 	GetSentBytes() int


### PR DESCRIPTION
Server can only listen and it should be listening on it's own localhost with a specific ip. This commit removes the ability for server to choose a different ip than localhost to listen to.