### PR TITLE
[iblt] Allow multiple retries with larger tablesize

### DIFF
--- a/pkg/lib/algorithm/full_sync/sync_test.go
+++ b/pkg/lib/algorithm/full_sync/sync_test.go
@@ -79,8 +79,8 @@ func TestNewFullSetSync(t *testing.T) {
 		assert.NoError(t, err)
 		wg.Wait()
 
-		assert.Len(t,*client.GetSetAdditions(),tt.serverSetSize-tt.intersectionSize)
-		assert.Len(t,*server.GetSetAdditions(),tt.clientSetSize-tt.intersectionSize)
+		assert.Len(t, *client.GetSetAdditions(), tt.serverSetSize-tt.intersectionSize)
+		assert.Len(t, *server.GetSetAdditions(), tt.clientSetSize-tt.intersectionSize)
 		assert.EqualValues(t, *server.GetLocalSet(), *client.GetLocalSet())
 	}
 }

--- a/pkg/lib/algorithm/iblt/options.go
+++ b/pkg/lib/algorithm/iblt/options.go
@@ -1,0 +1,81 @@
+package iblt
+
+import (
+	"crypto"
+	"fmt"
+)
+
+type ibltOptions struct {
+	HashSync          bool        // Converts data into hash values for IBLT and transfer literal data based on the differences. (enabled if HashFunc is provided)
+	HashFunc          crypto.Hash // the hash function to convert data into values for IBLT.
+	SymmetricDiff     int         // symmetrical set difference between set A and B  which is |A-B| + |B-A| (required)
+	DataLen           int         // maximum length of data elements (optional if HashSync is used.)
+	MaxSyncRetry      int         // IBLT is a probabilistic protocol and might need recomputing a table or double it's table size to be successful. This controls the number retires allowed. (default at 0)
+	TableSizeConstant float64     // TableSizeConstant * symmetric difference == number of table cells
+}
+
+func (i *ibltOptions) apply(options []IBLTOption) {
+	for _, option := range options {
+		option(i)
+	}
+}
+
+func (i *ibltOptions) complete() error {
+	if i.SymmetricDiff <= 0 {
+		return fmt.Errorf("number of difference should be positive")
+	}
+	// if Datalen is not set, which also says hash is not set, we go to default setting.
+	if i.DataLen == 0 {
+		i.HashSync = true
+		i.HashFunc = crypto.SHA256
+		i.DataLen = crypto.SHA256.Size()
+	}
+	if i.TableSizeConstant == 0 {
+		i.TableSizeConstant = 2.5
+	}
+	return nil
+}
+
+type IBLTOption func(option *ibltOptions)
+
+func WithSymmetricSetDiff(diffNum int) IBLTOption {
+	return func(option *ibltOptions) {
+		option.SymmetricDiff = diffNum
+	}
+}
+
+func WithHashSync() IBLTOption {
+	return func(option *ibltOptions) {
+		option.HashSync = true
+		option.HashFunc = crypto.SHA256
+		option.DataLen = crypto.SHA256.Size()
+	}
+}
+
+func WithHashFunc(hashFunc crypto.Hash) IBLTOption {
+	return func(option *ibltOptions) {
+		option.HashFunc = hashFunc
+		option.HashSync = true
+		option.DataLen = hashFunc.Size()
+	}
+}
+
+func WithDataLen(length int) IBLTOption {
+	return func(option *ibltOptions) {
+		option.DataLen = length
+		option.HashSync = false
+	}
+}
+
+func WithMaxSyncRetries(retries int) IBLTOption {
+	return func(option *ibltOptions) {
+		option.MaxSyncRetry = retries
+	}
+}
+
+// WithTableSizeConstant sets the table size by constant * symmetric difference. Default constant should be 1.5 according to the IBLT paper.
+func WithTableSizeConstant(constant float64) IBLTOption {
+	return func(option *ibltOptions) {
+		option.TableSizeConstant = constant
+	}
+}

--- a/pkg/lib/algorithm/iblt/sync_test.go
+++ b/pkg/lib/algorithm/iblt/sync_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWithDataLen(t *testing.T) {
-	rand.Seed(101)
+	rand.Seed(100)
 	tests := []struct {
 		serverSetSize    int
 		clientSetSize    int
@@ -44,10 +44,10 @@ func TestWithDataLen(t *testing.T) {
 		diffNum := tt.serverSetSize - tt.intersectionSize
 		diffNum += tt.clientSetSize - tt.intersectionSize
 
-		server, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(tt.dataLen))
+		server, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(tt.dataLen), WithMaxSyncRetries(2))
 		require.NoError(t, err)
 
-		client, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(tt.dataLen))
+		client, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(tt.dataLen), WithMaxSyncRetries(2))
 		require.NoError(t, err)
 
 		expectedSet := set.New()
@@ -89,11 +89,11 @@ func TestWithDataLen(t *testing.T) {
 		assert.NoError(t, err)
 		wg.Wait()
 
-		assert.Len(t,*client.GetSetAdditions(),tt.serverSetSize-tt.intersectionSize)
-		assert.Len(t,*server.GetSetAdditions(),tt.clientSetSize-tt.intersectionSize)
+		assert.Len(t, *client.GetSetAdditions(), tt.serverSetSize-tt.intersectionSize)
+		assert.Len(t, *server.GetSetAdditions(), tt.clientSetSize-tt.intersectionSize)
 
-		assert.EqualValues(t,*expectedClientExtra,*server.GetSetAdditions())
-		assert.EqualValues(t,*expectedServerExtra,*client.GetSetAdditions())
+		assert.EqualValues(t, *expectedClientExtra, *server.GetSetAdditions())
+		assert.EqualValues(t, *expectedServerExtra, *client.GetSetAdditions())
 
 		assert.EqualValues(t, *server.GetLocalSet(), *client.GetLocalSet())
 		assert.Equal(t, server.GetTotalBytes(), client.GetTotalBytes())
@@ -362,4 +362,88 @@ func TestIbltSync_SuccessRate(t *testing.T) {
 	}
 	swg.Wait()
 	t.Logf("IBLT success rate is %v", float32(samples-failed)/float32(samples))
+}
+
+func TestIbltSync_SuccessRateWithRetries(t *testing.T) {
+	samples := 10
+	concurrency := 10
+	maxSetSize := 1000
+	maxElementSize := 1000
+	retries := 5
+	failed := 0
+	var swg sync.WaitGroup
+	var mutex = &sync.Mutex{}
+	for i := 0; i < concurrency; i++ {
+		swg.Add(1)
+		go func(index int) {
+			index *= samples / concurrency
+			for j := 0; j < samples/concurrency; j++ {
+				index++
+				rand.Seed(int64(index))
+				dataLen := rand.IntnRange(1, maxElementSize)
+				serverSetSize := rand.IntnRange(0, maxSetSize)
+				clientSetSize := rand.IntnRange(0, maxSetSize)
+				intersectionSize := rand.IntnRange(0, func() int {
+					if serverSetSize == 0 || clientSetSize == 0 {
+						return 1
+					}
+					if serverSetSize > clientSetSize {
+						return clientSetSize
+					}
+					return serverSetSize
+				}())
+				diffNum := serverSetSize - intersectionSize
+				diffNum += serverSetSize - intersectionSize
+
+				server, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(dataLen), WithMaxSyncRetries(retries))
+				require.NoError(t, err)
+
+				client, err := NewIBLTSetSync(WithSymmetricSetDiff(diffNum), WithDataLen(dataLen), WithMaxSyncRetries(retries))
+				require.NoError(t, err)
+
+				expectedSet := set.New()
+				for i := 0; i < intersectionSize; i++ {
+					td := []byte(rand.String(dataLen))
+					err = server.AddElement(td)
+					require.NoError(t, err)
+					err = client.AddElement(td)
+					require.NoError(t, err)
+					expectedSet.InsertKey(td)
+				}
+
+				for i := 0; i < clientSetSize-intersectionSize; i++ {
+					td := []byte(rand.String(dataLen))
+					err = client.AddElement(td)
+					require.NoError(t, err)
+					expectedSet.InsertKey(td)
+				}
+
+				for i := 0; i < serverSetSize-intersectionSize; i++ {
+					td := []byte(rand.String(dataLen))
+					err = server.AddElement(td)
+					require.NoError(t, err)
+					expectedSet.InsertKey(td)
+				}
+
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					client.SyncServer("", 8080+index)
+					wg.Done()
+				}()
+				server.SyncClient("", 8080+index)
+				wg.Wait()
+				diff := server.GetLocalSet().Difference(client.GetLocalSet())
+				if diff.Len() != 0 {
+					t.Logf("Sync failed with %d difference.", diff.Len())
+					mutex.Lock()
+					failed++
+					mutex.Unlock()
+				}
+			}
+			swg.Done()
+		}(i)
+	}
+	swg.Wait()
+	t.Logf("IBLT success rate with %d retries is %v", retries, float32(samples-failed)/float32(samples))
 }

--- a/pkg/lib/genSync/connection.go
+++ b/pkg/lib/genSync/connection.go
@@ -19,6 +19,8 @@ type Connection interface {
 	ReceiveBytesSlice() ([][]byte, error)
 	SendSkipSyncBoolWithInfo(skipSync bool, format string, args ...interface{}) error
 	ReceiveSkipSyncBoolWithInfo(format string, args ...interface{}) (bool, error)
+	SendSyncStatus(syncStatus uint8) error
+	ReceiveSyncStatus() (uint8, error)
 	Close() error
 	GetIp() string
 	GetPort() string
@@ -180,6 +182,22 @@ func (s *socketConnection) ReceiveSkipSyncBoolWithInfo(format string, args ...in
 	}
 
 	return false, fmt.Errorf("error receiving skip sync signal")
+}
+
+func (s *socketConnection) SendSyncStatus(syncStatus uint8) error {
+	_, err := s.Send([]byte{syncStatus})
+	return err
+}
+
+func (s *socketConnection) ReceiveSyncStatus() (uint8, error) {
+	syncStatus, err := s.Receive()
+	if err != nil {
+		return 0, err
+	}
+	if len(syncStatus) == 1 {
+		return syncStatus[0], nil
+	}
+	return 0, fmt.Errorf("received unknown sync status: %v, sync status should not be more than 1 byte", syncStatus)
 }
 
 func (s *socketConnection) Close() error {

--- a/pkg/lib/genSync/interface.go
+++ b/pkg/lib/genSync/interface.go
@@ -12,7 +12,7 @@ type GenSync interface {
 	SyncServer(ip string, port int) error
 
 	GetLocalSet() *set.Set
-	GetSetAdditions() *set.Set 	// Set the set that is added to the local set.
+	GetSetAdditions() *set.Set // Set the set that is added to the local set.
 	GetSentBytes() int
 	GetReceivedBytes() int
 	GetTotalBytes() int

--- a/pkg/lib/genSync/types.go
+++ b/pkg/lib/genSync/types.go
@@ -5,4 +5,5 @@ const (
 	SYNC_FAIL     uint8 = 1
 	SYNC_SKIP     uint8 = 2
 	SYNC_CONTINUE uint8 = 3
+	SYNC_RETRY    uint8 = 4
 )


### PR DESCRIPTION
IBLT is a probablistic sync protocal. The size of the IBLT determins the probability of a successful sync. We allow retries on a failed sync attempt. The retries uses increased table size by 1 factor of their symetric difference. For example, to reconcile differences of 5, we might want to use rounded up 2.5 * diff number as the IBLT table size. The reties creates table of 3.5* diff number and 4.5, ..., etc, to increase the chance of successful sync upon every iteration. The IBLTs for retries are pre-computed and does not add up to sync time.